### PR TITLE
認証結果をtextviewに表示するよう変更

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,6 +23,13 @@ android {
         }
     }
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
 }
 
 dependencies {
@@ -31,6 +38,8 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.core:core-ktx:1.2.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation 'androidx.fragment:fragment-ktx:1.2.4'
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0"
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'

--- a/app/src/main/java/jp/kyamlab/biometricsample/MainActivity.kt
+++ b/app/src/main/java/jp/kyamlab/biometricsample/MainActivity.kt
@@ -83,7 +83,11 @@ class MainActivity : AppCompatActivity() {
                     super.onAuthenticationSucceeded(result)
                     val authenticatedCryptoObject: BiometricPrompt.CryptoObject? =
                         result.cryptoObject
-                    Log.d(TAG, "認証に成功しました")
+                    Log.d(
+                        TAG,
+                        AUTHENTICATED
+                    )
+                    textView.text = AUTHENTICATED
                 }
 
                 override fun onAuthenticationFailed() {
@@ -103,5 +107,6 @@ class MainActivity : AppCompatActivity() {
         // ログ表示用のタグ
         private const val TAG = "MainActivity"
         private const val ERROR_OCCURRED = "エラーが発生しました"
+        private const val AUTHENTICATED = "認証に成功しました"
     }
 }

--- a/app/src/main/java/jp/kyamlab/biometricsample/MainActivity.kt
+++ b/app/src/main/java/jp/kyamlab/biometricsample/MainActivity.kt
@@ -74,8 +74,9 @@ class MainActivity : AppCompatActivity() {
                     // 指紋認証に連続で失敗してロックされた時にも呼ばれる
                     Log.e(
                         TAG,
-                        "エラーが発生しました"
+                        ERROR_OCCURRED
                     )
+                    textView.text = ERROR_OCCURRED
                 }
 
                 override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
@@ -101,5 +102,6 @@ class MainActivity : AppCompatActivity() {
     companion object {
         // ログ表示用のタグ
         private const val TAG = "MainActivity"
+        private const val ERROR_OCCURRED = "エラーが発生しました"
     }
 }

--- a/app/src/main/java/jp/kyamlab/biometricsample/MainActivity.kt
+++ b/app/src/main/java/jp/kyamlab/biometricsample/MainActivity.kt
@@ -3,13 +3,17 @@ package jp.kyamlab.biometricsample
 import android.os.Bundle
 import android.util.Log
 import android.widget.Toast
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.biometric.BiometricManager
 import androidx.biometric.BiometricPrompt
+import androidx.lifecycle.observe
 import kotlinx.android.synthetic.main.activity_main.*
 import java.util.concurrent.Executors
 
 class MainActivity : AppCompatActivity() {
+
+    private val viewModel: MainViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -25,6 +29,10 @@ class MainActivity : AppCompatActivity() {
 
         button_authenticate.setOnClickListener {
             showBiometricPrompt()
+        }
+
+        viewModel.authenticateResult.observe(this) {
+            textView.text = it
         }
     }
 
@@ -76,7 +84,7 @@ class MainActivity : AppCompatActivity() {
                         TAG,
                         ERROR_OCCURRED
                     )
-                    textView.text = ERROR_OCCURRED
+                    viewModel.setAuthenticateResult(ERROR_OCCURRED)
                 }
 
                 override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
@@ -87,15 +95,16 @@ class MainActivity : AppCompatActivity() {
                         TAG,
                         AUTHENTICATED
                     )
-                    textView.text = AUTHENTICATED
+                    viewModel.setAuthenticateResult(AUTHENTICATED)
                 }
 
                 override fun onAuthenticationFailed() {
                     super.onAuthenticationFailed()
                     Log.e(
                         TAG,
-                        "認証に失敗しました"
+                        AUTHENTICATE_FAILED
                     )
+                    viewModel.setAuthenticateResult(AUTHENTICATE_FAILED)
                 }
             }
         )
@@ -108,5 +117,6 @@ class MainActivity : AppCompatActivity() {
         private const val TAG = "MainActivity"
         private const val ERROR_OCCURRED = "エラーが発生しました"
         private const val AUTHENTICATED = "認証に成功しました"
+        private const val AUTHENTICATE_FAILED = "認証に失敗しました"
     }
 }

--- a/app/src/main/java/jp/kyamlab/biometricsample/MainViewModel.kt
+++ b/app/src/main/java/jp/kyamlab/biometricsample/MainViewModel.kt
@@ -1,0 +1,15 @@
+package jp.kyamlab.biometricsample
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+
+class MainViewModel : ViewModel() {
+
+    private val _authenticateResult = MutableLiveData<String>()
+    val authenticateResult: LiveData<String> = _authenticateResult
+
+    fun setAuthenticateResult(result: String) {
+        _authenticateResult.postValue(result)
+    }
+}


### PR DESCRIPTION
## おこなったこと
- ViewModelの追加
- LiveDataの追加
- MainActivityのViewModelを作成
- ViewModelのLiveData経由で認証結果をMainActivityのTextViewに表示するよう変更

生体認証はワーカースレッドで実行されているためUIスレッドにアクセスできない。
よって、ViewModel経由でTextViewの表示を変更するようにした。